### PR TITLE
fixed youtube image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@
 - [All](https://github.com/s0md3v/ReconDog): Runs all utilities against the target
 
 ### Demo
-<img alt="demo" href="https://youtu.be/CHkIMcSzzCY" src="https://image.ibb.co/i11A69/Screenshot-2018-10-13-15-41-11.png">
+
+<p align="center">
+<a href="https://youtu.be/CHkIMcSzzCY">
+<img src="https://image.ibb.co/i11A69/Screenshot-2018-10-13-15-41-11.png">
+</a>
+</p>
 
 ### Compatibility
 Recon Dog will run on anything that has a python interpreter installed. However, it has been tested on the following configurations:


### PR DESCRIPTION
Hi,

I fixed a small thing in the README.md where when clicking on the image to view the YouTube video, you would only get the image not the video.