### PR TITLE
BugFix For Detect Technologies Not Working.

### DIFF
--- a/plugins/detectTech.py
+++ b/plugins/detectTech.py
@@ -4,10 +4,25 @@ from requests import get
 
 
 def detectTech(url):
-    data = get('https://api.wappalyzer.com/lookup-basic/beta/?url=' + url).text
+    api=''
+    
+    # wappalyzer.txt will store API key for future use.
+    try:
+
+      with open('wappalyzer_api_key.txt') as f:
+           api=f.read()
+
+    except FileNotFoundError:
+
+      api=input('\nPlease Enter Wappalyzer API KEY:')
+      with open('wappalyzer_api_key.txt','w') as w:
+           w.write(api)
+
+    data=get('https://api.wappalyzer.com/lookup/v2/?urls='+url,headers={'x-api-key':api}).text
     jsoned_data = json.loads(data)
     technologies = []
-    for one in jsoned_data:
+    for one in jsoned_data[0]['technologies']:
         technologies.append(one['name'])
     for tech in technologies:
-        sys.stdout.write(tech)
+        sys.stdout.write(tech+'\n')
+


### PR DESCRIPTION
Hi , wappalyzer.com needs API key to work with this Tool , also the json response from API was not compatible with current code
and gave errors. So I fixed all those problems. This Fix should close Issues #31 #32 #33

All the user has to do is enter the Wappalyzer.com API key which is available for free ( they have to sign up ) and enter it once. My code will store API key in a text file for future use.